### PR TITLE
Add daily quest and simple auto hunt

### DIFF
--- a/Ultimate/Game/Character.cs
+++ b/Ultimate/Game/Character.cs
@@ -1034,6 +1034,12 @@ namespace Ultimate.Game
         public byte BI_Quest_Completed = 0; // soft max 3
         public bool AC_Quest_Hops = false;
         public bool AC_Quest_Hops_Completed = false;
+        public bool DailyQuestActive = false;
+        public bool DailyQuestCompleted = false;
+        public int DailyQuestKills = 0;
+        public DateTime DailyQuestDate = DateTime.Today;
+        public bool AutoHuntEnabled = false;
+        private DateTime nextAutoHunt = DateTime.Now;
         public bool VIPMiningSkipOres = false;
         public bool VIPAura = false;
         public bool CountEffect = true;
@@ -7922,11 +7928,62 @@ namespace Ultimate.Game
                 Tank = true;
             CheckTank = false;
         }
+
+        private void AutoHuntStep()
+        {
+            if (!AutoHuntEnabled || !Alive)
+                return;
+            if (DateTime.Now < nextAutoHunt)
+                return;
+            nextAutoHunt = DateTime.Now.AddSeconds(1);
+
+            if (!World.H_Mobs.ContainsKey(Loc.Map))
+                return;
+
+            Game.Mob target = null;
+            int dist = int.MaxValue;
+            foreach (var m in World.H_Mobs[Loc.Map].Values)
+            {
+                if (!m.Alive)
+                    continue;
+                int d = MyMath.PointDistance(Loc.X, Loc.Y, m.Loc.X, m.Loc.Y);
+                if (d < dist)
+                {
+                    dist = d;
+                    target = m;
+                }
+            }
+            if (target == null)
+                return;
+
+            if (dist > 3)
+            {
+                ushort nx = (ushort)((Loc.X + target.Loc.X) / 2);
+                ushort ny = (ushort)((Loc.Y + target.Loc.Y) / 2);
+                if (AbleToJump(nx, ny, false, false))
+                {
+                    World.Action(this, Packets.GeneralData(EntityID, 0, nx, ny, 86).Get);
+                    Jump(nx, ny);
+                }
+            }
+            uint damage = PrepareAttack((byte)AttackType.Melee, true);
+            World.Action(this, Packets.AttackPacket(EntityID, target.EntityID, target.Loc.X, target.Loc.Y, damage, (byte)AttackType.Melee).Get);
+            target.TakeAttack(this, ref damage, AttackType.Melee, false);
+        }
         public void Step()
         {
             try
             {
                 DateTime TimeNow = DateTime.Now;
+                if (DailyQuestDate.Date != DateTime.Today)
+                {
+                    DailyQuestDate = DateTime.Today;
+                    DailyQuestActive = false;
+                    DailyQuestCompleted = false;
+                    DailyQuestKills = 0;
+                }
+
+                AutoHuntStep();
 
                 if (RemoveAfter && DateTime.Now > RemoveStamp)
                 {

--- a/Ultimate/Game/Mob.cs
+++ b/Ultimate/Game/Mob.cs
@@ -2878,6 +2878,15 @@ namespace Ultimate.Game
                                 }
                             }
                         }
+                        if (Char.DailyQuestActive && !Char.DailyQuestCompleted)
+                        {
+                            Char.DailyQuestKills += 1;
+                            if (Char.DailyQuestKills >= 100)
+                            {
+                                Char.DailyQuestCompleted = true;
+                                Char.MyClient.LocalMessage(2000, "You have completed the Daily Quest! Return to the Daily Quest Master.");
+                            }
+                        }
                     }
                     #endregion
                     #region Anniversary Quest

--- a/Ultimate/NPCs/Market/[6020] DailyQuestMaster.cs
+++ b/Ultimate/NPCs/Market/[6020] DailyQuestMaster.cs
@@ -1,0 +1,64 @@
+using Ultimate.Main;
+using System.Collections.Generic;
+using Ultimate.Game;
+
+namespace Ultimate.NPCs
+{
+    public class NPC_6020 : NPCBase
+    {
+        public NPC_6020(GameClient client) : base(client)
+        {
+            ID = 6020;
+            Face = 30;
+        }
+
+        public override void Run(GameClient GC, byte[] data, ushort linkback)
+        {
+            Responses = new List<COPacket>();
+            AddAvatar();
+            switch (linkback)
+            {
+                case 0:
+                    if (GC.MyChar.DailyQuestCompleted)
+                    {
+                        AddText("Great job! Here is your reward.");
+                        AddOption("Claim reward", 2);
+                    }
+                    else if (GC.MyChar.DailyQuestActive)
+                    {
+                        AddText($"Keep hunting! {GC.MyChar.DailyQuestKills}/100 monsters defeated.");
+                    }
+                    else
+                    {
+                        AddText("Would you like a task? Kill 100 monsters anywhere today.");
+                        AddOption("I'll do it", 1);
+                    }
+                    AddOption("Maybe later", 255);
+                    break;
+                case 1:
+                    GC.MyChar.DailyQuestActive = true;
+                    GC.MyChar.DailyQuestKills = 0;
+                    GC.MyChar.DailyQuestCompleted = false;
+                    GC.MyChar.DailyQuestDate = System.DateTime.Today;
+                    AddText("Come back when you've killed 100 monsters.");
+                    AddOption("OK", 255);
+                    break;
+                case 2:
+                    if (GC.MyChar.DailyQuestCompleted && GC.MyChar.GetAvailableInventorySlots() > 0)
+                    {
+                        GC.MyChar.AddItem(1088000);
+                        GC.MyChar.DailyQuestCompleted = false;
+                        AddText("Enjoy your DragonBall! Come back tomorrow for a new quest.");
+                    }
+                    else
+                    {
+                        AddText("You haven't completed the quest or don't have space.");
+                    }
+                    AddOption("Thanks", 255);
+                    break;
+            }
+            AddFinish();
+            Send();
+        }
+    }
+}

--- a/Ultimate/PacketHandling/Chat.cs
+++ b/Ultimate/PacketHandling/Chat.cs
@@ -1442,12 +1442,19 @@ namespace Ultimate.PacketHandling
                                     GC.LocalMessage(2000, "Objective: Collect 5 hops from any of the following: Macaque, MacaqueL48, GiantApe, GiantApeL53, ThunderApe or ThunderApeL58.");
                                     GC.LocalMessage(2000, "Return to Breeder in Ape City (550,598) when your done.");
                                 }
+                                if (GC.MyChar.DailyQuestActive)
+                                {
+                                    GC.LocalMessage(2000, "Quest: Daily Hunt (Market 180,220)");
+                                    GC.LocalMessage(2000, $"Objective: Kill 100 monsters. Progress: {GC.MyChar.DailyQuestKills}/100");
+                                }
                                 if (GC.MyChar.BI_Quest == 0 && !GC.MyChar.AC_Quest_Hops)
                                     GC.LocalMessage(2000, "You don't have any active quests.");
                                 if (GC.MyChar.BI_Quest == 0)
                                     GC.LocalMessage(2000, "[QUEST] Animal Purification (Bird Island 747,517) is available.");
                                 if (!GC.MyChar.AC_Quest_Hops)
                                     GC.LocalMessage(2000, "[QUEST] Stress Relief (Ape City 550,598) is available.");
+                                if (!GC.MyChar.DailyQuestActive && !GC.MyChar.DailyQuestCompleted)
+                                    GC.LocalMessage(2000, "[QUEST] Daily Hunt (Market 180,220) is available.");
                                 break;
                             #endregion
                             #region /command
@@ -1478,6 +1485,13 @@ namespace Ultimate.PacketHandling
                             case "@plvloff":
                                 if (World.Archers.ContainsKey(GC.MyChar.EntityID))
                                     World.Archers.Remove(GC.MyChar.EntityID);
+                                break;
+                            #endregion
+
+                            #region /autohunt
+                            case "@autohunt":
+                                GC.MyChar.AutoHuntEnabled = !GC.MyChar.AutoHuntEnabled;
+                                GC.LocalMessage(2000, GC.MyChar.AutoHuntEnabled ? "Auto Hunt enabled." : "Auto Hunt disabled.");
                                 break;
                             #endregion
 

--- a/Ultimate/Ultimate.csproj
+++ b/Ultimate/Ultimate.csproj
@@ -688,6 +688,7 @@
     <Compile Include="NPCs\Market\[35016] WuxingOven.cs" />
     <Compile Include="NPCs\Market\[390] LoveStone.cs" />
     <Compile Include="NPCs\Market\[44] Warehouseman.cs" />
+    <Compile Include="NPCs\Market\[6020] DailyQuestMaster.cs" />
     <Compile Include="NPCs\Market\[45] Conductress.cs" />
     <Compile Include="NPCs\Market\[5004] MillionaireLee.cs" />
     <Compile Include="NPCs\Market\[5015] MillionaireLeeGem.cs" />


### PR DESCRIPTION
## Summary
- implement daily quest tracking fields and auto hunt in `Character`
- count quest kills for new daily quest
- add `@quests` info and `@autohunt` command
- create new NPC `DailyQuestMaster` to start and claim daily quests
- include new NPC in project file

## Testing
- `dotnet build` *(fails: command not found)*
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c808e81a0832485a06a66db0d89d2